### PR TITLE
Use macos instead of osx64

### DIFF
--- a/neva
+++ b/neva
@@ -391,7 +391,7 @@ function M.install(version, ...)
    if OS_TYPE == "linux" then
       TAR_NAME = TAR_NAME .. "linux64"
    elseif OS_TYPE == "darwin" or os_type == "mac" then
-      TAR_NAME = TAR_NAME .. "osx64"
+      TAR_NAME = TAR_NAME .. "macos"
    end
    remove_dir(NEVA_VER_HOME .. "/" .. TAR_NAME)
 


### PR DESCRIPTION
Seems that upstream updated the minimum macOS version to have universal builds for Intel and M1.

See more details here: https://github.com/neovim/neovim/pull/19029